### PR TITLE
feat：導線の変更。

### DIFF
--- a/src/components/RankingDialog.js
+++ b/src/components/RankingDialog.js
@@ -20,7 +20,7 @@ const RankingDialog = ({ open, onClose, money }) => {
     if (shouldRecord) {
       setOpenInput(true);
     } else {
-      navigate(`/Ranking`);
+      navigate(`/`);
     }
   };
 
@@ -31,11 +31,6 @@ const RankingDialog = ({ open, onClose, money }) => {
     }
     setOpenInput(false);
     await addRankingTable(name, money);
-    navigate(`/Ranking`);
-  };
-
-  const handleCancel = () => {
-    setOpenInput(false);
     navigate(`/Ranking`);
   };
 
@@ -70,10 +65,7 @@ const RankingDialog = ({ open, onClose, money }) => {
             inputProps={{ maxLength: 10 }}
           />
         </DialogContent>
-        <DialogActions style={{ justifyContent: "space-between" }}>
-          <Button onClick={handleCancel} color="secondary">
-            スコアを記録せずランキングを確認する
-          </Button>
+        <DialogActions>
           <Button onClick={handleInputClose} color="primary">
             確定
           </Button>

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -42,18 +42,8 @@ const Result = () => {
           <ValueBox text={`所持金：${money}`} />
         </Box>
         <Box mt={5}>
-          <Button
-            variant="contained"
-            onClick={() => {
-              navigate(`/`);
-            }}
-          >
-            スタートへ
-          </Button>
-        </Box>
-        <Box mt={5}>
           <Button variant="contained" onClick={handleClickOpenConfirm}>
-            ランキング
+            スタートへ
           </Button>
         </Box>
       </Box>


### PR DESCRIPTION
- リザルト画面での従来の「ランキング（はい／いいえ）」ボタンの機能を「スタート」ボタンに持たせました。
- 導線の変更に伴い、ランキングニックネーム入力フォームの「スコアを記録せずランキングを確認する」を削除しました。

![image](https://github.com/user-attachments/assets/c9ffbcd2-2946-4292-95d0-620f310b21fe)
![image](https://github.com/user-attachments/assets/2d410f6e-f3da-469e-b70f-30e5ae2ac211)
